### PR TITLE
Add basic Telegram bot example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# Telegram Bot Example
+
+This repository contains a simple Telegram bot implemented using the [`python-telegram-bot`](https://github.com/python-telegram-bot/python-telegram-bot) library.
+
+The bot sends the message **"Привет"** when you send the `/start` command.
+
+## Setup
+
+1. Install the `python-telegram-bot` package:
+   ```bash
+   pip install python-telegram-bot
+   ```
+2. Obtain a bot token from [@BotFather](https://t.me/BotFather) on Telegram and place it in `telegram_bot.py` by replacing `YOUR_BOT_TOKEN_HERE`.
+3. Run the bot:
+   ```bash
+   python telegram_bot.py
+   ```
+
+The bot will start polling for updates. When you send `/start` to the bot, it will reply "Привет".

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -1,0 +1,19 @@
+import logging
+from telegram import Update
+from telegram.ext import ApplicationBuilder, CommandHandler, ContextTypes
+
+BOT_TOKEN = "YOUR_BOT_TOKEN_HERE"
+
+logging.basicConfig(format='%(asctime)s - %(name)s - %(levelname)s - %(message)s', level=logging.INFO)
+
+async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    await update.message.reply_text('Привет')
+
+async def main():
+    application = ApplicationBuilder().token(BOT_TOKEN).build()
+    application.add_handler(CommandHandler('start', start))
+    await application.run_polling()
+
+if __name__ == '__main__':
+    import asyncio
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- implement simple Telegram bot using `python-telegram-bot`
- provide README with setup instructions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f5b97e544832aadca19e3bc1fb35d